### PR TITLE
Modifying build_tag.sh script to utilize local go installation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,8 @@
 project_name: ocm-addons
 before:
   hooks:
-    - ./mage check:tidy
-    - ./mage check:verify
+    - go mod tidy
+    - go mod verify
 builds:
   - env:
       - CGO_ENABLED=0

--- a/build_tag.sh
+++ b/build_tag.sh
@@ -2,9 +2,11 @@
 
 set -exvo pipefail -o nounset
 
-docker login quay.io -u ${QUAY_USER} -p ${QUAY_TOKEN}
+# utilize local go 1.17 version if available
+GO_1_17="/opt/go/1.17.5/bin"
 
-IMAGE=ocm-addons-ci
+if [ -d  "${GO_1_17}" ]; then
+     PATH="${GO_1_17}:${PATH}"
+fi
 
-docker build -t ${IMAGE} -f Dockerfile.ci .
-docker run --rm -e "GITHUB_TOKEN=${GITHUB_TOKEN}" "${IMAGE}" release:full
+echo "$(curl -sL https://git.io/goreleaser) --rm-dist" | bash


### PR DESCRIPTION
### Summary

Favoring use of local go installation for goreleaser instead of using the sandbox container.