### PR TITLE
Pinning `pre-commit` to 2.17.0 for Python 3.6.x compatibility

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
@@ -166,12 +165,8 @@ func (Deps) UpdatePreCommit(ctx context.Context) error {
 
 	const urlPrefix = "https://github.com/pre-commit/pre-commit/releases/download"
 
-	version, err := tools.GetLatestTag(ctx, "pre-commit", "pre-commit")
-	if err != nil {
-		return fmt.Errorf("retrieving latest pre-commit release: %w", err)
-	}
-
-	version = strings.TrimPrefix(version, "v")
+	// pinning to version 2.17.0 since 2.18.0+ requires python>=3.7
+	const version = "2.17.0"
 
 	out := filepath.Join(_depBin, "pre-commit")
 


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>] - '-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
Python 3.6.x compatibility was dropped with `pre-commit 2.18.0` hence pinning to `2.17.0` until CI system versions are bumped.
  
### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
Docs/Test

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] All CI checks and tests are passing.

### Additional Information

<!-- Report any other relevant details below -->
https://github.com/pre-commit/pre-commit/releases/tag/v2.18.0