### PR TITLE
Switch mage check:license dependency from 'install' to 'build'

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -219,7 +219,7 @@ var _binDir = filepath.Join(_projectRoot, "bin")
 // this repository's license (Apache 2.0).
 func (Check) License() error {
 	mg.Deps(
-		Build.Install,
+		Build.Plugin,
 		Deps.UpdateLichen,
 	)
 


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>] - '-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
The `license-check` pre-commit hook currently depends on plugin installation which previously left a build artifact in the bin folder. Currently the installation no longer leaves that binary artifact so the dependency must be switched to "build:plugin"

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
Docs/Test

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] All CI checks and tests are passing.

### Additional Information

<!-- Report any other relevant details below -->
