### PR TITLE
[MTSRE-504] - Make `cluster events` return all events

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,12 +25,15 @@ snapshot:
 changelog:
   use: github
   groups:
-    - title: Changes
-      regexp: "^.*feature[(\\w)]*:+.*$"
+    - title: Breaking
+      regexp: "^.*(fix|feat)[(\\w)]*!:+.*$"
       order: 0
+    - title: Changes
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 10
     - title: Bugfixes
       regexp: "^.*fix[(\\w)]*:+.*$"
-      order: 10
+      order: 20
     - title: Trivial
       order: 999
   filters:

--- a/cmd/ocm-addons/cluster/events/cmd.go
+++ b/cmd/ocm-addons/cluster/events/cmd.go
@@ -159,10 +159,10 @@ func run(opts *options) func(cmd *cobra.Command, args []string) error {
 }
 
 func commandOptsToGetLogsOpts(opts *options) (ocm.GetLogsOptions, error) {
-	pattern := "Add-on%"
+	pattern := ""
 
 	if opts.Search != "" {
-		pattern += fmt.Sprintf("%s%%", opts.Search)
+		pattern += fmt.Sprintf("%%%s%%", opts.Search)
 	}
 
 	if err := opts.ParseFilterOptions(); err != nil {


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>] - '-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
Removes the restriction that only _addon_ related cluster events are returned by `ocm addons cluster events`

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] All CI checks and tests are passing.

### Additional Information

<!-- Report any other relevant details below -->
