### PR TITLE
[MTSRE-509] Unbreak 'Windows' builds

### DIFF
--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strings"
 
@@ -186,7 +186,7 @@ func loadNotifications(dataDir fs.ReadDirFS) (ConfigTree, error) {
 	for _, dir := range teamDirs {
 		teamName := dir.Name()
 
-		subFS, err := fs.Sub(dataDir, filepath.Join(_dataDirName, teamName))
+		subFS, err := fs.Sub(dataDir, path.Join(_dataDirName, teamName))
 		if err != nil {
 			return nil, fmt.Errorf("subbing team directory: %w", err)
 		}
@@ -250,7 +250,7 @@ func loadTeamConfigDirectory(dir fs.FS) (map[string]map[string]Config, error) {
 			return nil, fmt.Errorf("loading config file %q: %w", name, err)
 		}
 
-		key := strings.TrimSuffix(name, filepath.Ext(name))
+		key := strings.TrimSuffix(name, path.Ext(name))
 
 		result[key] = configs
 	}


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>] - '-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
Windows build have been broken since #27 since `embed` filesystems only resolve path's using `/` as a separator which is incompatible with `filepath` for operating systems using other separators.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] All CI checks and tests are passing.

### Additional Information

<!-- Report any other relevant details below -->
