### PR TITLE
ci: overridding archive format to '.zip' for windows archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,23 +1,27 @@
 project_name: ocm-addons
 before:
   hooks:
-    - go mod tidy
-    - go mod verify
+  - go mod tidy
+  - go mod verify
 builds:
-  - env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-      - darwin
-      - windows
-    main: ./cmd/ocm-addons
-    binary: ocm-addons
-    ldflags:
-      - -s -w
-      - -X 'github.com/mt-sre/ocm-addons/internal/meta.version={{.Version}}'
-      - -X 'github.com/mt-sre/ocm-addons/internal/meta.commit={{.Commit}}'
-      - -X 'github.com/mt-sre/ocm-addons/internal/meta.date={{.Date}}'
-      - -X 'github.com/mt-sre/ocm-addons/internal/meta.builtBy=goreleaser'
+- env:
+  - CGO_ENABLED=0
+  goos:
+  - linux
+  - darwin
+  - windows
+  main: ./cmd/ocm-addons
+  binary: ocm-addons
+  ldflags:
+  - -s -w
+  - -X 'github.com/mt-sre/ocm-addons/internal/meta.version={{.Version}}'
+  - -X 'github.com/mt-sre/ocm-addons/internal/meta.commit={{.Commit}}'
+  - -X 'github.com/mt-sre/ocm-addons/internal/meta.date={{.Date}}'
+  - -X 'github.com/mt-sre/ocm-addons/internal/meta.builtBy=goreleaser'
+archives:
+- format_overrides:
+  - goos: windows
+    format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -25,19 +29,19 @@ snapshot:
 changelog:
   use: github
   groups:
-    - title: Breaking
-      regexp: "^.*(fix|feat)[(\\w)]*!:+.*$"
-      order: 0
-    - title: Changes
-      regexp: "^.*feat[(\\w)]*:+.*$"
-      order: 10
-    - title: Bugfixes
-      regexp: "^.*fix[(\\w)]*:+.*$"
-      order: 20
-    - title: Trivial
-      order: 999
+  - title: Breaking
+    regexp: "^.*(fix|feat)[(\\w)]*!:+.*$"
+    order: 0
+  - title: Changes
+    regexp: "^.*feat[(\\w)]*:+.*$"
+    order: 10
+  - title: Bugfixes
+    regexp: "^.*fix[(\\w)]*:+.*$"
+    order: 20
+  - title: Trivial
+    order: 999
   filters:
     exclude:
-      - Merge pull request
-      - '^docs:'
-      - '^test:'
+    - Merge pull request
+    - '^docs:'
+    - '^test:'


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>] - '-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
Archives `Windows` releases artifacts using `zip` rather than `tar.gz`.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
<!-- Bug Fix -->
<!-- Docs/Test -->
Release

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] All CI checks and tests are passing.

### Additional Information

<!-- Report any other relevant details below -->
