### PR TITLE
[MTSRE-563] feat: add creator fields to subscriptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,16 +47,6 @@ repos:
   - id: check-yaml
   - id: detect-private-key
 
-- repo: https://github.com/jackdewinter/pymarkdown
-  rev: v0.9.5
-  hooks:
-  - id: pymarkdown
-    exclude: 'pull_request_template.md'
-    args:
-    - -d
-    - md013
-    - scan
-
 - repo: local
   hooks:
   - id: golangci-lint

--- a/cicd/jenkins_env.sh
+++ b/cicd/jenkins_env.sh
@@ -6,8 +6,3 @@ GO_1_17="/opt/go/1.17.7/bin"
 if [ -d  "${GO_1_17}" ]; then
      PATH="${GO_1_17}:${PATH}"
 fi
-
-PYTHON_VERSION="$(python3 -c 'import sys; print(*sys.version_info[:3])')"
-PYTHON_MAJOR_VERSION=$(echo "${PYTHON_VERSION}" | cut -d' ' -f1)
-PYTHON_MINOR_VERSION=$(echo "${PYTHON_VERSION}" | cut -d' ' -f2)
-PYTHON_PATCH_VERSION=$(echo "${PYTHON_VERSION}" | cut -d' ' -f3)

--- a/internal/ocm/cluster.go
+++ b/internal/ocm/cluster.go
@@ -110,6 +110,7 @@ func (c *Cluster) WithSubscription(ctx context.Context) (*Cluster, error) {
 		Subscriptions().
 		Subscription(c.cluster.Subscription().ID()).
 		Get().
+		Parameter("fetchAccounts", true).
 		SendContext(ctx)
 	if err != nil {
 		return c, err
@@ -412,7 +413,11 @@ func (s *Subscription) ProvideRowData() map[string]interface{} {
 	}
 
 	return map[string]interface{}{
-		"Organization ID": s.sub.OrganizationID(),
-		"Support Level":   s.sub.SupportLevel(),
+		"Creator ID":       s.sub.Creator().ID(),
+		"Creator Email":    s.sub.Creator().Email(),
+		"Creator Name":     fmt.Sprintf("%s %s", s.sub.Creator().FirstName(), s.sub.Creator().LastName()),
+		"Creator Username": s.sub.Creator().Username(),
+		"Organization ID":  s.sub.OrganizationID(),
+		"Support Level":    s.sub.SupportLevel(),
 	}
 }

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -4,10 +4,4 @@ set -exvo pipefail -o nounset
 
 source "${PWD}/cicd/jenkins_env.sh"
 
-SKIP=""
-
-if ! [[ (${PYTHON_MAJOR_VERSION} -eq 3 && ${PYTHON_MINOR_VERSION} -ge 8) ]]; then
-     SKIP="pymarkdown"
-fi
-
-SKIP="${SKIP}" ./mage -t 10m run-hooks && ./mage -t 10m test
+./mage -t 10m run-hooks && ./mage -t 10m test


### PR DESCRIPTION
<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>] - '-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Adds the ability to retrieve details about the creator of a subscription (cluster).

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] All CI checks and tests are passing.

### Additional Information

<!-- Report any other relevant details below -->
