### PR TITLE
bump go-ci to v0.6.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 
 require gopkg.in/yaml.v3 v3.0.1
 
-require github.com/mt-sre/go-ci v0.6.0
+require github.com/mt-sre/go-ci v0.6.1
 
 require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mt-sre/go-ci v0.6.0 h1:ZP+CrajrFvnyqpKjlNH3v4+70lhW658EvSquSPJny9Q=
-github.com/mt-sre/go-ci v0.6.0/go.mod h1:Rhc+vQ+8uOiIhFJ6Pnyas4UB29BJsxmLKGmLCmzEi5s=
+github.com/mt-sre/go-ci v0.6.1 h1:9yas9JkSO7r8sRLvXqahpdPUe9fT3ASJPJDVInQCT/0=
+github.com/mt-sre/go-ci v0.6.1/go.mod h1:Rhc+vQ+8uOiIhFJ6Pnyas4UB29BJsxmLKGmLCmzEi5s=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/magefile.go
+++ b/magefile.go
@@ -13,11 +13,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 	"github.com/mt-sre/go-ci/command"
+	"github.com/mt-sre/go-ci/git"
 	"github.com/mt-sre/go-ci/web"
 )
 
@@ -89,16 +89,15 @@ var _projectRoot = func() string {
 		return root
 	}
 
-	topLevel := git(command.WithArgs{"rev-parse", "--show-toplevel"})
-
-	if err := topLevel.Run(); err != nil || !topLevel.Success() {
-		panic("failed to get working directory")
+	topLevel, err := git.RevParse(context.Background(),
+		git.WithRevParseFormat(git.RevParseFormatTopLevel),
+	)
+	if err != nil {
+		panic(err)
 	}
 
-	return strings.TrimSpace(topLevel.Stdout())
+	return topLevel
 }()
-
-var git = command.NewCommandAlias("git")
 
 type Deps mg.Namespace
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Red Hat, Inc. <sd-mt-sre@redhat.com>

SPDX-License-Identifier: Apache-2.0
-->

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>] - '-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

Bumps `go-ci` to `v0.6.1`.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] All CI checks and tests are passing.

### Additional Information

<!-- Report any other relevant details below -->
