### PR TITLE
fix: bump module versions to go1.19

### DIFF
--- a/cicd/jenkins_env.sh
+++ b/cicd/jenkins_env.sh
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # utilize local go 1.18 version if available
-GO_1_18="/opt/go/1.18.1/bin"
+GO_1_19="/opt/go/1.19.3/bin"
 
-if [ -d  "${GO_1_18}" ]; then
-     PATH="${GO_1_18}:${PATH}"
+if [ -d  "${GO_1_19}" ]; then
+     PATH="${GO_1_19}:${PATH}"
 fi

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/mt-sre/ocm-addons
 
-go 1.18
+go 1.19
 
 require (
 	github.com/apex/log v1.9.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -4,7 +4,7 @@
 
 module tools
 
-go 1.18
+go 1.19
 
 require (
 	github.com/golangci/golangci-lint v1.50.1


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Red Hat, Inc. <sd-mt-sre@redhat.com>

SPDX-License-Identifier: Apache-2.0
-->

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>] - '-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
Bumps modules to `go1.19`.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [ ] All CI checks and tests are passing.

### Additional Information

<!-- Report any other relevant details below -->
