### PR TITLE
fix: only return managed clusters when listing

### DIFF
--- a/internal/ocm/cluster_pager.go
+++ b/internal/ocm/cluster_pager.go
@@ -19,7 +19,7 @@ const (
 // RetrieveClusters initializes a ClusterPager which will request clusters from OCM with a fixed page size.
 func RetrieveClusters(conn *sdk.Connection, logger log.Interface) (*ClusterPager, error) {
 	request := &clustersListRequest{
-		conn.ClustersMgmt().V1().Clusters().List(),
+		conn.ClustersMgmt().V1().Clusters().List().Parameter("managed", true),
 	}
 
 	return &ClusterPager{


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Red Hat, Inc. <sd-mt-sre@redhat.com>

SPDX-License-Identifier: Apache-2.0
-->

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>] - '-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
Reduces cluster output to only `managed` clusters.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] All CI checks and tests are passing.

### Additional Information

<!-- Report any other relevant details below -->
