### PR TITLE
fix: add handling for Apple Silicon uname -m output

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,7 +37,9 @@ function system_kernel() {
 }
 
 function system_arch() {
-     case "$(uname -m)" in
+     arch="$(uname -m)"
+
+     case "${arch}" in
           "x86_64")
           echo "amd64"
           ;;
@@ -48,7 +50,7 @@ function system_arch() {
           echo "arm64"
           ;;
           *)
-          echo ""
+          "${arch}"
           ;;
      esac
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Red Hat, Inc. <sd-mt-sre@redhat.com>

SPDX-License-Identifier: Apache-2.0
-->

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>] - '-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->
Fixes `install.sh` to handle `uname -m` output when no explicit match is made.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
<!-- New Feature -->
Bug Fix
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [x] This PR is fully tested and regression tests are included.
- [x] All CI checks and tests are passing.

### Additional Information

<!-- Report any other relevant details below -->
