### PR TITLE
feat: expose cluster search query to `addon installations` command via cli flag

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
+version: "2"
 run:
   build-tags:
     - codeanalysis
@@ -11,29 +12,18 @@ linters:
   disable:
   # not neccessary right now
   - depguard
-  # Deprecated
-  - golint
-  - interfacer
-  - maligned
-  - scopelint
   # Only meant to be applied selectively.
   - exhaustruct
-  - exhaustivestruct
   # Promotes use of trivially shortened statements rather than
   # lower complexity functions.
   - funlen
-  # Standard import ordering is fine for now.
-  - gci
   # Globals still in use for singleton-esque objects.
   - gochecknoglobals
   # False reports.
-  - ifshort
   - nilerr
   # Interface returns are currently used to wrap chained methods
   # methods from the 'ocm-sdk'.
   - ireturn
-  # Incorrectly reports '_' prefixed package globals
-  - nosnakecase
   # Does not support map[string]testcase style subtests.
   - paralleltest
   # Ineffective for foreign schemas

--- a/cmd/ocm-addons/installations/cmd.go
+++ b/cmd/ocm-addons/installations/cmd.go
@@ -19,12 +19,14 @@ func Cmd() *cobra.Command {
 	var opts options
 
 	opts.DefaultColumns("addon_id, addon_name, installed_version_id, cluster_id, cluster_name, cluster_state, state")
+	opts.SearchUsage("only list addons on clusters that match the given search query")
 
 	return generateCommand(&opts, run(&opts))
 }
 
 type options struct {
 	cli.CommonOptions
+	cli.SearchOptions
 }
 
 const longDescription = `List all installations of a given add-on by cluster in the current OCM environment.
@@ -43,6 +45,7 @@ func generateCommand(options *options, run func(*cobra.Command, []string) error)
 	options.AddColumnsFlag(flags)
 	options.AddNoColorFlag(flags)
 	options.AddNoHeadersFlag(flags)
+	options.AddSearchFlag(flags)
 
 	return cmd
 }
@@ -90,6 +93,10 @@ func run(opts *options) func(cmd *cobra.Command, args []string) error { //nolint
 		clusters, err := ocm.RetrieveClusters(sess.Conn(), trace)
 		if err != nil {
 			return err
+		}
+
+		if opts.Search != "" {
+			clusters = clusters.Search(opts.Search)
 		}
 
 		if err := clusters.ForEach(ctx, func(cluster *ocm.Cluster) error {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2022 Red Hat, Inc. <sd-mt-sre@redhat.com>

SPDX-License-Identifier: Apache-2.0
-->

<!-- If this PR is linked to a Jira ticket prefix your title with '[<PROJECT>-<KEY>] - '-->
### Summary
<!-- Briefly describe what this PR accomplishes -->
<!-- Hint: If this resolves an issue include 'resolves #XXX' -->

This PR exposes cluster filtering via ocm search query to the `installations` command to allow invocations like:

`ocm addons installations --search "name like 'hs-%'"`

This drastically reduces query time to enumerate addons on a known and queryable set of clusters.

### Change Type

<!-- Uncomment one of the following -->
<!-- Breaking Change -->
New Feature
<!-- Bug Fix -->
<!-- Docs/Test -->

### Check List Before Merging

- [x] This PR passes all pre-commit hook validations.
- [ ] This PR is fully tested and regression tests are included.
- [ ] All CI checks and tests are passing.

### Additional Information

<!-- Report any other relevant details below -->
